### PR TITLE
Add option lookups and delays to ZWave

### DIFF
--- a/MIG.HomeAutomation/ZWave.cs
+++ b/MIG.HomeAutomation/ZWave.cs
@@ -627,6 +627,9 @@ namespace MIG.Interfaces.HomeAutomation
             if (this.GetOption("Delay") != null)
                 controller.CommandDelay = int.Parse(this.GetOption("Delay").Value);
 
+            if (this.GetOption("StartupDiscovery") != null && this.GetOption("StartupDiscovery").Value == "0")
+                controller.StartupDiscovery = false;
+
             controller.PortName = this.GetOption("Port").Value;
             controller.Connect();
             return true;
@@ -721,7 +724,8 @@ namespace MIG.Interfaces.HomeAutomation
                 break;
             case ControllerStatus.Ready:
                 // Query all nodes (Basic Classes, Node Information Frame, Manufacturer Specific[, Command Class version])
-                controller.Discovery();
+                if(controller.StartupDiscovery)
+                    controller.Discovery();
                 break;
             case ControllerStatus.Error:
                 controller.Connect();

--- a/MIG.HomeAutomation/ZWave.cs
+++ b/MIG.HomeAutomation/ZWave.cs
@@ -234,6 +234,9 @@ namespace MIG.Interfaces.HomeAutomation
 
         public object InterfaceControl(MigInterfaceCommand request)
         {
+            while(controller.CommandDelay > 0 && controller.LastCommand.AddMilliseconds(controller.CommandDelay) > DateTime.Now) { }
+            controller.LastCommand = DateTime.Now;
+
             string returnValue = "";
             bool raiseEvent = false;
             string eventParameter = ModuleEvents.Status_Level;
@@ -621,6 +624,9 @@ namespace MIG.Interfaces.HomeAutomation
 
         public bool Connect()
         {
+            if (this.GetOption("Delay") != null)
+                controller.CommandDelay = int.Parse(this.GetOption("Delay").Value);
+
             controller.PortName = this.GetOption("Port").Value;
             controller.Connect();
             return true;


### PR DESCRIPTION
I was having some timing problems with my controller, and found that adding a small delay between commands helped considerably. This will vary from configuration to configuration, so it's selectable in the ZWave Interface Options page. Also, the controller discovery on restart locks the system up until discovery is complete, which takes a considerable while on 50+ devices, so I made it optional.
