### PR TITLE
Fix issue with URL encoded options passed from Wizard Script command.

### DIFF
--- a/MIG/MigInterfaceCommand.cs
+++ b/MIG/MigInterfaceCommand.cs
@@ -56,8 +56,16 @@ namespace MIG
                         Command = requests[2];
                         if (requests.Length > 3)
                         {
-                            options = new string[requests.Length - 3];
-                            Array.Copy(requests, 3, options, 0, requests.Length - 3);
+                            var decodedFirstOption = System.Uri.UnescapeDataString(requests[3]);
+                            if(decodedFirstOption == requests[3])
+                            {
+                                options = new string[requests.Length - 3];
+                                Array.Copy(requests, 3, options, 0, requests.Length - 3);
+                            }
+                            else // if we have URL encoded options
+                            {
+                                options = decodedFirstOption.Trim('/').Split(new char[] { '/' }, StringSplitOptions.None);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Found an issue that Wizard Script command's options are URL encoded. It caused following bug: I tried to set parameter of my ZWave dimmer, so the command looked like `HomeAutomation.ZWave/15/Config.ParameterSet/12/5` in UI. But the program didn't work. After some investigation I found following lines in console:

```
2015-11-29 00:08:37.2694 Error HomeAutomation.HomeGenie InterfaceControl    Input string was not in the correct format  Exception.StackTrace
  at System.Int32.Parse (System.String s) [0x00000] in <filename unknown>:0 
at MIG.Interfaces.HomeAutomation.ZWave.InterfaceControl (MIG.MigInterfaceCommand request) [0x00000] in <filename unknown>:0 
at HomeGenie.Service.HomeGenieService.InterfaceControl (MIG.MigInterfaceCommand cmd) [0x00000] in <filename unknown>:0 
```

After adding additional tracing to MIG library I found that the command was passed as `HomeAutomation.ZWave/15/Config.ParameterSet/12%2F5`, so the couple of options wasn't splitted.
