### PR TITLE
Revert "Fix issue with URL encoded options passed from Wizard Script command."

### DIFF
--- a/MIG/MigInterfaceCommand.cs
+++ b/MIG/MigInterfaceCommand.cs
@@ -56,16 +56,8 @@ namespace MIG
                         Command = requests[2];
                         if (requests.Length > 3)
                         {
-                            var decodedFirstOption = System.Uri.UnescapeDataString(requests[3]);
-                            if(decodedFirstOption == requests[3])
-                            {
-                                options = new string[requests.Length - 3];
-                                Array.Copy(requests, 3, options, 0, requests.Length - 3);
-                            }
-                            else // if we have URL encoded options
-                            {
-                                options = decodedFirstOption.Trim('/').Split(new char[] { '/' }, StringSplitOptions.None);
-                            }
+                            options = new string[requests.Length - 3];
+                            Array.Copy(requests, 3, options, 0, requests.Length - 3);
                         }
                     }
                 }


### PR DESCRIPTION
Reverts genielabs/mig-service-dotnet#4
this solution cannot be applied since it prevent / symbol from being encoded as part of a value.
